### PR TITLE
add tsconfigFile to the preprocessor

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,11 @@ export default {
   },
   plugins: [
     svelte({
-      preprocess: sveltePreprocess(),
+      preprocess: sveltePreprocess({
+          typescript: {
+            tsconfigFile: production ? "./tsconfig.svelte.prod.json" : "./tsconfig.svelte.json",
+          }
+        }),
       compilerOptions: {
         // enable run-time checks when not in production
         dev: !production,


### PR DESCRIPTION
Upgrading svelte-preprocess from 4.6.9 to 4.7.0 broke rollup build with the following error:

```
(plugin svelte) TypeError: The "path" argument must be of type string. Received undefined
```

Little problem with finding the TS config file.